### PR TITLE
fix: Prevent MangleCssClassPlugin from altering 'false' in JavaScript

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -141,7 +141,7 @@ module.exports = {
       }
     }),
     new MangleCssClassPlugin({
-      classNameRegExp: '((fa|clazz)-([a-zA-Z0-9-]+)|fa(b?))',
+      classNameRegExp: '(fa|clazz)-([a-zA-Z0-9-]+)',
       reserveClassName: ['fa', 'fab'],
       mangleCssVariables: true,
       log: true,


### PR DESCRIPTION
Resolved an issue where MangleCssClassPlugin mistakenly replaced 'fa' and 'fab' in JavaScript, causing 'false' to become 'alse'.