### PR TITLE
feat: Add caching headers for static assets in firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,12 +8,24 @@
     ],
     "rewrites": [
       {
-        "source": "/watchfaces-privacy-policy",
-        "destination": "/watchfaces-privacy-policy.html"
-      },
-      {
         "source": "**",
         "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "**/*.@(ico|jpg|jpeg|gif|png|webp|js|css)",
+        "headers" : [{
+          "key" : "Cache-Control",
+          "value" : "max-age=31536000"
+        }]
+      },
+      {
+        "source": "**/*.@(eot|otf|ttf|ttc|woff|woff2|font.css)",
+        "headers" : [{
+          "key" : "Cache-Control",
+          "value" : "max-age=31536000"
+        }]
       }
     ]
   }


### PR DESCRIPTION
Configured `Cache-Control` headers with a max-age of 1 year for static assets (images, fonts, JavaScript, and CSS) to improve caching and performance.