### PR TITLE
fix: Update HtmlWebpackPlugin to use valid HTML5 script tags

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,6 +89,7 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       alwaysWriteToDisk: true,
+      scriptLoading: 'blocking',
       template: htmlWebpackPluginTemplateCustomizer({
         templatePath: 'src/views/index.ejs',
         templateEjsLoaderOption: {


### PR DESCRIPTION
Set `scriptLoading: 'blocking'` in HtmlWebpackPlugin to remove `type="defer"` from inline script tags, ensuring compliance with HTML5 standards.