### PR TITLE
fix: Use ES export for analytics.js

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -16,7 +16,4 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
   
 // Initialize Analytics and get a reference to the service
-const analytics = getAnalytics(app);
-
-// Export analytics
-module.exports = analytics;
+export const analytics = getAnalytics(app);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,13 +20,14 @@ const context = path.join(__dirname, 'src');
 const outputDir = path.join(__dirname, 'dist');
 
 module.exports = {
-  mode: "production",
+    mode: "production",
     entry: {
         index: './src/js/index.js',
         pageNotFound: './src/js/404.js',
     },
     output: {
         path: outputDir,
+        publicPath: '',
         filename: '[name].[contenthash:8].js',
         sourceMapFilename: '[name].[contenthash:8].js.map',
         chunkFilename: '[id].[contenthash:8].js',


### PR DESCRIPTION
Replaced CommonJS module export with ES export in `analytics.js` to ensure compatibility with the project setup.