### PR TITLE
fix: Disable removeComments in HtmlWebpackPlugin to retain license files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -158,7 +158,7 @@ module.exports = {
       hash: false,
       minify: {
         collapseWhitespace: true,
-        removeComments: true,
+        removeComments: false,
         minifyCSS: true,
         minifyJS: true,
       }
@@ -179,7 +179,7 @@ module.exports = {
       hash: false,
       minify: {
         collapseWhitespace: true,
-        removeComments: true,
+        removeComments: false,
         minifyCSS: true,
         minifyJS: true,
       }


### PR DESCRIPTION
Turned off `removeComments` in HtmlWebpackPlugin to ensure comments are preserved for Terser, enabling the generation of `[name].[hash].js.LICENSE.txt` files.