### PR TITLE
feat: add HtmlNewLineRemoverPlugin to remove all newline characters from HTML output

### DIFF
--- a/html-new-line-remover-plugin.js
+++ b/html-new-line-remover-plugin.js
@@ -1,0 +1,17 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+class HtmlNewLineRemoverPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('HtmlNewLineRemoverPlugin', (compilation) => {
+      HtmlWebpackPlugin.getHooks(compilation).beforeEmit.tapAsync(
+        'HtmlNewLineRemoverPlugin',
+        (data, cb) => {
+          data.html = data.html.replace(/(\r)?\n|\r/g, '');
+          cb(null, data);
+        }
+      );
+    });
+  }
+}
+
+module.exports = HtmlNewLineRemoverPlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ const MangleCssClassPlugin = require('mangle-css-class-webpack-plugin');
 const HtmlInlineScriptWebpackPlugin = require('html-inline-script-webpack-plugin');
 const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
 const SitemapWebpackPlugin = require('sitemap-webpack-plugin').default;
+const HtmlNewLineRemoverPlugin = require('./html-new-line-remover-plugin.js');
 
 const { interpolateName } = require('loader-utils');
 const fs = require('fs');
@@ -175,6 +176,7 @@ module.exports = {
         lastmod: true,
       }
     }),
+    new HtmlNewLineRemoverPlugin(),
   ],
   optimization: {
     minimize: true,


### PR DESCRIPTION
- Introduced a custom Webpack plugin (`HtmlNewLineRemoverPlugin`) to remove CRLF, CR, and LF characters from generated HTML files.
- Hooked into `HtmlWebpackPlugin`'s `beforeEmit` lifecycle to process the HTML and normalize line endings.
- Updated `webpack.config.js` to include the new plugin in the `plugins` array for seamless integration.
- Ensured compatibility with both Unix (`\n`) and Windows (`\r\n`) newline formats.