### PR TITLE
chore: Add workflow for deleting Firebase Hosting channels on PR closure

### DIFF
--- a/.github/workflows/delete-firebase-hosting-channel.yml
+++ b/.github/workflows/delete-firebase-hosting-channel.yml
@@ -1,0 +1,17 @@
+name: On PR closed - Delete firebase hosting channel
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  delete_firebase_channel:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: w9jds/firebase-action@818980820c18bcd6a2e3e4739c6fe174ce5b467f # v13.27.0
+        with:
+          args: hosting:channel:delete ${{ github.head_ref }} --force
+        env:
+          GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BVARGA_FE600 }}
+          PROJECT_ID: bvarga-fe600

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,13 +11,13 @@ jobs:
       name: production
       url: https://bvarga.dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: '.node-version'
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         env:
           cache-name: cache-node-modules
         with:
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Build and Test
         run: ./scripts/build.sh
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@0cbcac4740c2bfb00d632f0b863b57713124eb5a # v0.9.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BVARGA_FE600 }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-24.04
     environment: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: '.node-version'
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         env:
           cache-name: cache-node-modules
         with:
@@ -23,7 +23,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Build and Test
         run: ./scripts/build.sh
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@0cbcac4740c2bfb00d632f0b863b57713124eb5a # v0.9.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BVARGA_FE600 }}'


### PR DESCRIPTION
- Added `.github/workflows/delete-firebase-hosting-channel.yml`:
  - Automatically deletes Firebase Hosting preview channels when a pull request is closed.
  - Uses `w9jds/firebase-action` pinned to v13.27.0 for stability.
- Updated Firebase Hosting workflows to pin action versions for consistency:
  - `actions/checkout` pinned to v4.2.2.
  - `actions/setup-node` pinned to v4.1.0.
  - `actions/cache` pinned to v4.1.2.
  - `FirebaseExtended/action-hosting-deploy` pinned to v0.9.0.
- Ensures reproducibility and stability across workflows.