### PR TITLE
fix: Correct channel deletion logic in Firebase workflow

### DIFF
--- a/.github/workflows/delete-firebase-hosting-channel.yml
+++ b/.github/workflows/delete-firebase-hosting-channel.yml
@@ -11,7 +11,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: w9jds/firebase-action@818980820c18bcd6a2e3e4739c6fe174ce5b467f # v13.27.0
         with:
-          args: hosting:channel:delete ${{ github.head_ref }} --force
+          # Extracts the full channel name from the PR number and feeds it to the delete command
+          args: hosting:channel:list | grep 'pr${{ github.event.pull_request.number }}' | cut --delimeter ' ' --fields 2 | xargs -I {} firebase hosting:channel:delete --force {}
         env:
           GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BVARGA_FE600 }}
           PROJECT_ID: bvarga-fe600


### PR DESCRIPTION
- **Improved Logic**:
  - Updated the `delete-firebase-hosting-channel.yml` workflow to dynamically resolve the full channel name based on the pull request number.
  - Uses `grep` and `cut` to extract the channel name from the `hosting:channel:list` command.
  - Ensures robust and accurate deletion of the associated Firebase hosting channel.

- **Enhancements**:
  - Added logic to safely pass the resolved channel name to the `firebase hosting:channel:delete` command using `xargs`.
  - Maintains backward compatibility with the existing environment variables and configurations.

- **Objective**:
  - Automate cleanup of Firebase hosting channels linked to pull requests for better resource management.