### PR TITLE
fix: Correct typo in `cut` command for Firebase channel deletion workflow

### DIFF
--- a/.github/workflows/delete-firebase-hosting-channel.yml
+++ b/.github/workflows/delete-firebase-hosting-channel.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: w9jds/firebase-action@12e7dd1a31239567f9b4d398e6c1dc9f1c6fc70a # v13.28.0
         with:
           # Extracts the full channel name from the PR number and feeds it to the delete command
-          args: hosting:channel:list | grep 'pr${{ github.event.pull_request.number }}' | cut --delimeter ' ' --fields 2 | xargs -I {} firebase hosting:channel:delete --force {}
+          args: hosting:channel:list | grep 'pr${{ github.event.pull_request.number }}' | cut --delimiter ' ' --fields 2 | xargs -I {} firebase hosting:channel:delete --force {}
         env:
           GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BVARGA_FE600 }}
           PROJECT_ID: bvarga-fe600


### PR DESCRIPTION
- **Change**:
  - Fixed the `cut` command by correcting the spelling of `--delimiter` and properly setting its syntax in the `args` field of the `delete-firebase-hosting-channel.yml` workflow.

- **Purpose**:
  - Ensure the command extracts the correct channel name from the Firebase hosting channel list, improving the reliability of pull request cleanup.

- **Impact**:
  - Resolves potential failures caused by invalid `cut` command options in the Firebase channel deletion process.