### PR TITLE
feat: Enhance CSP in `webpack.config.js` for stricter security policies

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -202,14 +202,17 @@ module.exports = {
     }),
     new HtmlNewLineRemoverPlugin(),
     new CspHtmlWebpackPlugin(
-     {
-       'default-src': "'self'",
-       'script-src': ["'self'", "https://www.googletagmanager.com"],
-       'style-src': ["'self'"],
-       'img-src': ["'self'"],
-       'font-src': ["'self'"],
-       'connect-src': ["'self'", "https://*.google-analytics.com", "https://firebase.googleapis.com", "https://firebaseinstallations.googleapis.com"],
-     },
+      {
+        'base-uri': "'self'",
+        'default-src': "'self'",
+        'script-src': ["'strict-dynamic'", 'https://www.googletagmanager.com', "'unsafe-inline'"],
+        'style-src': ["'unsafe-inline'"],
+        'img-src': ["'self'"],
+        'font-src': ["'self'"],
+        'connect-src': ["'self'", 'https://*.google-analytics.com', 'https://firebase.googleapis.com', 'https://firebaseinstallations.googleapis.com'],
+        'object-src': "'none'",
+        'require-trusted-types-for': "'script'",
+      },
      {
        hashingMethod: 'sha256',
        enabled: true,


### PR DESCRIPTION
- **Changes**:
  - Refined the `CspHtmlWebpackPlugin` configuration:
    - Added `base-uri` directive with `'self'`.
    - Updated `script-src` to include `'strict-dynamic'` and `'unsafe-inline'` for better compatibility with dynamic scripts.
    - Enabled `'unsafe-inline'` for `style-src` to accommodate inline styles.
    - Explicitly disabled `object-src` with `'none'`.
    - Added `require-trusted-types-for` to enforce Trusted Types for scripts.
  - Commented out `StrictCspHtmlWebpackPlugin` for potential future use with `enableTrustedTypes`.

- **Purpose**:
  - Strengthen security by enhancing Content Security Policy (CSP) directives.

- **Impact**:
  - Reduces vulnerabilities to XSS and related attacks while allowing necessary script and style flexibility.