### PR TITLE
fix: Update cache-control headers in Firebase transformer

### DIFF
--- a/transformer-firebase.js
+++ b/transformer-firebase.js
@@ -27,7 +27,7 @@ module.exports = (headers) => {
                     headers: [
                         {
                             key: 'Cache-Control',
-                            value: 's-maxage=31536000,immutable',
+                            value: 'max-age=31536000,s-maxage=31536000,immutable',
                         },
                     ],
                 },
@@ -36,20 +36,11 @@ module.exports = (headers) => {
                     headers: [
                         {
                             key: 'Cache-Control',
-                            value: 's-maxage=31536000,immutable',
+                            value: 'max-age=31536000,s-maxage=31536000,immutable',
                         },
                     ],
                 },
                 ...headers,
-                //{
-                //    source: '**',
-                //    headers: Object.entries({
-                //        ...headers,
-                //    }).map(([key, value]) => ({
-                //        key,
-                //        value,
-                //    })),
-                //},
             ],
         },
     };


### PR DESCRIPTION
- Adjusted `Cache-Control` headers in `transformer-firebase.js`:
  - Added `max-age=31536000` to complement `s-maxage=31536000` and ensure consistent cache behavior across all levels.
  - Ensures better compatibility and optimized caching for static assets.

- Removed commented-out unused code for cleaner and more maintainable configuration.

- **Impact**:
  - Improves caching efficiency for assets by aligning cache-control directives.
  - Simplifies the Firebase hosting configuration for enhanced clarity.