### PR TITLE
fix: Remove rewrites to enable Firebase use of 404.html as default

### DIFF
--- a/transformer-firebase.js
+++ b/transformer-firebase.js
@@ -15,12 +15,6 @@ module.exports = (headers) => {
                 '**/.*',
                 '**/node_modules/**',
             ],
-            rewrites: [
-                {
-                    "source": "**",
-                    "destination": "/404.html"
-                },
-            ],
             headers: [
                 {
                     source: '**/*.@(ico|jpg|jpeg|gif|png|webp|js.map|js|css|txt|html)',


### PR DESCRIPTION
- **Changes**:
  - Removed the `rewrites` block from `transformer-firebase.js`.

- **Impact**:
  - Ensures Firebase correctly uses `404.html` as the default error page.
  - Corrects the returned HTTP status code to 404 instead of 200 for missing routes.

- **Reason**:
  - Aligns with Firebase best practices for handling 404 errors with proper status codes.